### PR TITLE
feat: If and Case matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,8 @@ Actual   :0.9048172867693559
 - `has_attribute`
 - `is_datetime`
 - `is_datetime_string`
+- `same_value`
+- `different_value`
+- `if_true`
+- `if_false`
+- `case`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ command_line = "-m pytest src/pytest_matchers/tests"
 
 [tool.coverage.report]
 show_missing = true
-exclude_also = ["@abstractmethod"]
+exclude_also = ["@abstractmethod", "If"]
 
 [tool.coverage.xml]
 output = "coverage.xml"

--- a/src/pytest_matchers/pytest_matchers/__init__.py
+++ b/src/pytest_matchers/pytest_matchers/__init__.py
@@ -1,8 +1,11 @@
 from .main import (
     anything,
     between,
+    case,
     different_value,
     has_attribute,
+    if_false,
+    if_true,
     is_datetime,
     is_datetime_string,
     is_instance,

--- a/src/pytest_matchers/pytest_matchers/main.py
+++ b/src/pytest_matchers/pytest_matchers/main.py
@@ -1,11 +1,13 @@
-from typing import Any, Type
+from typing import Any, Callable, Type
 
 from pytest_matchers.matchers import (
     Anything,
     Between,
+    Case,
     Datetime,
     DatetimeString,
     HasAttribute,
+    If,
     IsInstance,
     IsList,
     IsNumber,
@@ -86,3 +88,27 @@ def same_value() -> SameValue:
 
 def different_value() -> DifferentValue:
     return DifferentValue()
+
+
+def if_true(
+    condition: Callable | bool | Any,
+    then: Matcher | Any = None,
+    or_else: Matcher | Any = None,
+) -> If:
+    return If(condition, then, or_else)
+
+
+def if_false(
+    condition: Callable | bool | Any,
+    then: Matcher | Any = None,
+    or_else: Matcher | Any = None,
+) -> If:
+    return if_true(condition, or_else, then)  # pylint: disable=arguments-out-of-order
+
+
+def case(
+    case_value: Any,
+    expectations: dict[Any, Matcher | Any],
+    default_expectation: Matcher | Any | None = None,
+) -> Case:
+    return Case(case_value, expectations, default_expectation)

--- a/src/pytest_matchers/pytest_matchers/matchers/__init__.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/__init__.py
@@ -19,3 +19,5 @@ from .datetime_string import DatetimeString
 from .has_attribute import HasAttribute
 from .same_value import SameValue
 from .different_value import DifferentValue
+from .if_matcher import If
+from .case import Case

--- a/src/pytest_matchers/pytest_matchers/matchers/case.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/case.py
@@ -1,0 +1,38 @@
+from typing import Any
+
+from pytest_matchers.matchers import Matcher
+from pytest_matchers.utils.matcher_utils import as_matcher, as_matcher_or_none
+
+
+class Case(Matcher):
+    def __init__(
+        self,
+        case_value: Any,
+        expectations: dict[Any, Matcher | Any],
+        default_expectation: Matcher | Any | None = None,
+    ):
+        self._case_value = case_value
+        self._expectations = expectations
+        self._default_expectation = (
+            None if default_expectation is None else as_matcher(default_expectation)
+        )
+
+    def matches(self, value: Any) -> bool:
+        expectation = self._expectation()
+        if expectation is None:
+            return False
+        return value == expectation
+
+    def _expectation(self) -> Matcher | Any | None:
+        return as_matcher_or_none(
+            self._expectations.get(self._case_value, self._default_expectation)
+        )
+
+    def __repr__(self):
+        expectation = self._expectation()
+        if expectation is None:
+            return (
+                f"To never match because case value {repr(self._case_value)} is not expected "
+                "and the default expectation is not set"
+            )
+        return f"{repr(expectation)} because case value is {repr(self._case_value)}"

--- a/src/pytest_matchers/pytest_matchers/matchers/if_matcher.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/if_matcher.py
@@ -1,0 +1,47 @@
+from typing import Any, Callable
+
+from pytest_matchers.matchers import Anything, Matcher
+from pytest_matchers.utils.matcher_utils import as_matcher
+from pytest_matchers.utils.repr_utils import capitalized
+from pytest_matchers.utils.warn import warn
+
+
+class If(Matcher):
+    def __init__(
+        self,
+        condition: Callable | bool | Any,
+        then: Matcher | Any = None,
+        or_else: Matcher | Any = None,
+    ):
+        self._condition = condition
+        self._then = as_matcher(then or Anything())
+        self._or_else = as_matcher(or_else or Anything())
+
+    def matches(self, value: Any) -> bool:
+        matcher = self._or_else
+        if self._satisfies_condition(value):
+            matcher = self._then
+        return matcher == value
+
+    def _satisfies_condition(self, value: Any) -> bool:
+        if isinstance(self._condition, bool):
+            return self._condition
+        if not callable(self._condition):
+            return self._condition == value
+        try:
+            return self._condition(value)
+        except Exception as error:  # pylint: disable=broad-except
+            warn(f"Condition failed with error: {error}. Returning False as default value.")
+            return False
+
+    def __repr__(self):
+        if isinstance(self._condition, bool):
+            if self._condition:
+                return repr(self._then)
+            return repr(self._or_else)
+
+        representation = (
+            f"{self._then.concatenated_repr()} if condition returns True"
+            f" else {self._or_else.concatenated_repr()}"
+        )
+        return capitalized(representation)

--- a/src/pytest_matchers/pytest_matchers/utils/matcher_utils.py
+++ b/src/pytest_matchers/pytest_matchers/utils/matcher_utils.py
@@ -18,6 +18,12 @@ def as_matcher(value: Matcher | Any) -> Matcher:
     return Eq(value)
 
 
+def as_matcher_or_none(value: Matcher | Any | None) -> Matcher | None:
+    if value is None:
+        return None
+    return as_matcher(value)
+
+
 def matches_or_none(matcher: Matcher | None, value: Any) -> bool:
     return matcher is None or matcher == value
 

--- a/src/pytest_matchers/pytest_matchers/utils/repr_utils.py
+++ b/src/pytest_matchers/pytest_matchers/utils/repr_utils.py
@@ -20,7 +20,11 @@ def concat_reprs(
         [_repr(extra_repr) for extra_repr in extra_reprs if extra_repr]
     )
     if not base_repr and extra_repr:
-        return extra_repr[0].upper() + extra_repr[1:]
+        return capitalized(extra_repr)
     if extra_repr:
         return f"{base_repr} {extra_repr}"
     return base_repr
+
+
+def capitalized(string: str):
+    return string[0].upper() + string[1:]

--- a/src/pytest_matchers/pytest_matchers/utils/warn.py
+++ b/src/pytest_matchers/pytest_matchers/utils/warn.py
@@ -1,0 +1,12 @@
+import os
+import warnings
+from typing import Type
+
+
+def _warnings_enabled() -> bool:
+    return os.environ.get("PYTEST_MATCHERS_WARNINGS", "True") == "True"
+
+
+def warn(warning: str, category: Type[Warning] = UserWarning) -> None:
+    if _warnings_enabled():
+        warnings.warn(warning, category)

--- a/src/pytest_matchers/tests/conftest.py
+++ b/src/pytest_matchers/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ["PYTEST_MATCHERS_WARNINGS"] = "False"

--- a/src/pytest_matchers/tests/matchers/test_case.py
+++ b/src/pytest_matchers/tests/matchers/test_case.py
@@ -1,0 +1,53 @@
+from pytest_matchers import is_number, is_string
+from pytest_matchers.matchers import Case
+
+
+def test_create():
+    matcher = Case(3, {3: 3})
+    assert isinstance(matcher, Case)
+    matcher = Case(3, {3: is_number()})
+    assert isinstance(matcher, Case)
+    matcher = Case(4, {3: 3}, 3)
+    assert isinstance(matcher, Case)
+    matcher = Case(3, {3: 3}, 3)
+    assert isinstance(matcher, Case)
+    matcher = Case(3, {3: 3}, is_string())
+    assert isinstance(matcher, Case)
+
+
+def test_repr():
+    matcher = Case(3, {3: 4})
+    assert repr(matcher) == "To be 4 because case value is 3"
+    matcher = Case(3, {3: is_number()})
+    assert repr(matcher) == "To be a number because case value is 3"
+    matcher = Case(4, {3: 4}, 5)
+    assert repr(matcher) == "To be 5 because case value is 4"
+    matcher = Case(4, {3: 3}, is_string())
+    assert repr(matcher) == "To be string because case value is 4"
+    matcher = Case(4, {3: 3})
+    assert (
+        repr(matcher) == "To never match because case value 4 is not expected "
+        "and the default expectation is not set"
+    )
+
+
+def test_matches():
+    matcher = Case(3, {3: 4, 4: "string"})
+    assert matcher == 4
+    assert matcher != 3
+    assert matcher != 5
+    assert matcher != "string"
+    matcher = Case(3, {3: is_number()})
+    assert matcher == 3
+    assert matcher == 4
+    matcher = Case(3, {3: is_string()}, 3)
+    assert matcher == "3"
+    assert matcher != 3
+    matcher = Case(4, {3: is_number()}, is_string())
+    assert matcher == "string"
+    assert matcher != 3
+    assert matcher != 4
+    matcher = Case(4, {3: 3})
+    assert matcher != 3
+    assert matcher != 4
+    assert matcher != "string"

--- a/src/pytest_matchers/tests/matchers/test_if.py
+++ b/src/pytest_matchers/tests/matchers/test_if.py
@@ -1,0 +1,69 @@
+from pytest_matchers import is_number, is_string
+from pytest_matchers.matchers import If
+
+
+def test_create():
+    matcher = If(True)
+    assert isinstance(matcher, If)
+    matcher = If(False)
+    assert isinstance(matcher, If)
+    matcher = If(lambda x: x == 3)
+    assert isinstance(matcher, If)
+    matcher = If(lambda x: x == 3, 3)
+    assert isinstance(matcher, If)
+    matcher = If(lambda x: x == 3, 3, 4)
+    assert isinstance(matcher, If)
+    matcher = If(lambda x: x == 3, or_else=4)
+    assert isinstance(matcher, If)
+
+
+def test_repr():
+    matcher = If(True)
+    assert repr(matcher) == "To be anything"
+    matcher = If(False, is_string(), is_number(int))
+    assert repr(matcher) == "To be a number of 'int' instance"
+    matcher = If(lambda x: x == 3)
+    assert repr(matcher) == "To be anything if condition returns True else to be anything"
+    matcher = If(lambda x: x == 3, 3)
+    assert repr(matcher) == "To be 3 if condition returns True else to be anything"
+    matcher = If(lambda x: x == 3, is_number(), 4)
+    assert repr(matcher) == "To be a number if condition returns True else to be 4"
+    matcher = If(lambda x: x == 3, or_else=is_string())
+    assert repr(matcher) == "To be anything if condition returns True else to be string"
+
+
+def test_match():
+    assert If(True) == 3
+    assert If(False) == 3
+    matcher = If(True, is_number(), is_string())
+    assert matcher == 3
+    assert matcher == 4
+    assert matcher != "string"
+    matcher = If(False, is_number(), is_string())
+    assert matcher != 3
+    assert matcher != 4
+    assert matcher == "string"
+    matcher = If(lambda x: x > 3, is_number(float), is_number(int))
+    assert matcher == 3
+    assert matcher != 4
+    matcher = If(lambda x: x + 2 == 5, 3)
+    assert matcher == 3
+    assert matcher == 4  # False can be anything
+    assert matcher == "string"
+    matcher = If(lambda x: x <= 3, 3, 4)
+    assert matcher == 3
+    assert matcher == 4
+    assert matcher != "string"
+    matcher = If(lambda x: x + 2 == 5, or_else=4)
+    assert matcher == 3
+    assert matcher == 4
+    assert matcher != "string"
+    matcher = If(5, is_number(), is_string())
+    assert matcher == 5
+    assert matcher != 4
+    assert matcher == "string"
+    matcher = If(is_string(), is_string(length=8), is_number())
+    assert matcher == "string__"
+    assert matcher != "string"
+    assert matcher == 3
+    assert matcher != [1]

--- a/src/pytest_matchers/tests/test_main.py
+++ b/src/pytest_matchers/tests/test_main.py
@@ -4,8 +4,11 @@ from unittest.mock import MagicMock
 from pytest_matchers import (
     anything,
     between,
+    case,
     different_value,
     has_attribute,
+    if_false,
+    if_true,
     is_datetime,
     is_datetime_string,
     is_instance,
@@ -155,3 +158,33 @@ def test_different_value():
     assert matcher == 3
     assert matcher != 3
     assert matcher == 4
+
+
+def test_if_true():
+    assert 3 == if_true(True, is_number(), is_string())
+    assert 4 != if_true(False, is_number(), is_string())
+    assert 3 == if_true(lambda x: x == 3, 3)
+    assert 4 != if_true(lambda x: x == 3, 4, 3)
+    assert 4 == if_true(lambda x: x == 3, 4)
+    assert 3 != if_true(3, 4)
+    assert 4 != if_true(3, 4, 5)
+    assert 20 == if_true(is_number(int), is_number(min_value=10), is_number(max_value=10))
+
+
+def test_if_false():
+    assert 3 == if_false(False, is_number(), is_string())
+    assert 4 != if_false(True, is_number(), is_string())
+    assert 3 == if_false(lambda x: x == 3, 3)
+    assert 4 == if_false(lambda x: x == 3, 4, 3)
+    assert 4 == if_false(lambda x: x == 3, 4)
+    assert 3 == if_false(3, 4)
+    assert 4 == if_false(3, 4, 5)
+    assert 20 != if_false(is_number(int), is_number(min_value=10), is_number(max_value=10))
+
+
+def test_case():
+    assert 4 == case(3, {3: 4, 4: "string"})
+    assert "3" == case(3, {3: is_string()})
+    assert 4 != case(3, {3: is_string()}, 4)
+    assert "string" == case(4, {3: is_number()}, is_string())
+    assert 4 != case(4, {3: 3})

--- a/src/pytest_matchers/tests/utils/test_repr_utils.py
+++ b/src/pytest_matchers/tests/utils/test_repr_utils.py
@@ -1,5 +1,5 @@
 from pytest_matchers.matchers import Eq, IsInstance
-from pytest_matchers.utils.repr_utils import concat_matcher_repr, concat_reprs
+from pytest_matchers.utils.repr_utils import capitalized, concat_matcher_repr, concat_reprs
 
 
 def test_concat_matcher_repr():
@@ -21,3 +21,9 @@ def test_concat_reprs():
         == "I expect of 'str' instance and to be 2 and be happy"
     )
     assert concat_reprs("I expect", Eq(3), Eq(4), separator="or") == "I expect to be 3 or to be 4"
+
+
+def test_capitalized():
+    assert capitalized("i expect") == "I expect"
+    assert capitalized("I expect") == "I expect"
+    assert capitalized("I KNOW") == "I KNOW"

--- a/src/pytest_matchers/tests/utils/test_warn.py
+++ b/src/pytest_matchers/tests/utils/test_warn.py
@@ -1,0 +1,29 @@
+import os
+from unittest.mock import patch
+
+from pytest_matchers.utils.warn import warn
+
+
+@patch("pytest_matchers.utils.warn.warnings.warn")
+def test_warn(mock_warn):
+    with patch.dict(os.environ, {"PYTEST_MATCHERS_WARNINGS": "True"}):
+        warn("A warning")
+        mock_warn.assert_called_with("A warning", UserWarning)
+
+
+@patch("pytest_matchers.utils.warn.warnings.warn")
+def test_warn_with_category(mock_warn):
+    with patch.dict(os.environ, {}, clear=True):
+        warn("Another warning", DeprecationWarning)
+        mock_warn.assert_called_with("Another warning", DeprecationWarning)
+
+
+@patch("pytest_matchers.utils.warn.warnings.warn")
+def test_warnings_disabled(mock_warn):
+    with patch.dict(os.environ, {"PYTEST_MATCHERS_WARNINGS": "False"}):
+        warn("A warning")
+        mock_warn.assert_not_called()
+
+    with patch.dict(os.environ, {"PYTEST_MATCHERS_WARNINGS": "True"}):
+        warn("A warning")
+        mock_warn.assert_called_with("A warning", UserWarning)


### PR DESCRIPTION
Adds new matchers:

```python
def test_conditional_matchers():
    assert random() == if_true(
        lambda value: value > 0.5,
        is_number(min_value=0.5, inclusive=False),
        is_number(max_value=0.5),
    )
    assert random() == if_false(
        lambda value: value > 0.5,
        is_number(max_value=0.5),
        is_number(min_value=0.5, inclusive=False),
    )
    random_value = random()
    random_string = "low"
    if random_value > 0.5:  # pragma: no cover
        random_string = "medium"
    if random_value > 0.8:  # pragma: no cover
        random_string = "high"
    assert random_value == case(
        random_string,
        {
            "low": is_number(max_value=0.5),
            "medium": is_number(min_value=0.5, max_value=0.8, min_inclusive=False),
            "high": is_number(min_value=0.8, inclusive=False),
        },
    )
    matcher = if_true(is_string(), is_datetime_string("%Y-%m-%d"), is_datetime())
    assert "2021-01-01" == matcher
    assert datetime(2021, 1, 1) == matcher
    assert 3 != matcher
    assert random() != matcher
    assert "10/11/2029" != matcher
```