### PR TITLE
feat: Add dictionary matcher

### DIFF
--- a/src/pytest_matchers/pytest_matchers/__init__.py
+++ b/src/pytest_matchers/pytest_matchers/__init__.py
@@ -8,6 +8,7 @@ from .main import (
     if_true,
     is_datetime,
     is_datetime_string,
+    is_dict,
     is_instance,
     is_list,
     is_number,

--- a/src/pytest_matchers/pytest_matchers/main.py
+++ b/src/pytest_matchers/pytest_matchers/main.py
@@ -6,6 +6,8 @@ from pytest_matchers.matchers import (
     Case,
     Datetime,
     DatetimeString,
+    Dict,
+    DifferentValue,
     HasAttribute,
     If,
     IsInstance,
@@ -15,7 +17,6 @@ from pytest_matchers.matchers import (
     Matcher,
     Or,
     SameValue,
-    DifferentValue,
 )
 
 
@@ -112,3 +113,7 @@ def case(
     default_expectation: Matcher | Any | None = None,
 ) -> Case:
     return Case(case_value, expectations, default_expectation)
+
+
+def is_dict(matching: dict = None, exclude: list[Any] = None) -> Dict:
+    return Dict(matching, exclude)

--- a/src/pytest_matchers/pytest_matchers/matchers/__init__.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/__init__.py
@@ -21,3 +21,4 @@ from .same_value import SameValue
 from .different_value import DifferentValue
 from .if_matcher import If
 from .case import Case
+from .dict import Dict

--- a/src/pytest_matchers/pytest_matchers/matchers/dict.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/dict.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from pytest_matchers.matchers import IsInstance, Matcher
+from pytest_matchers.utils.matcher_utils import as_matcher
+from pytest_matchers.utils.repr_utils import concat_reprs
+
+
+class Dict(Matcher):
+    def __init__(self, matching: dict = None, exclude: list[Any] = None):
+        self._is_instance_matcher = IsInstance(dict)
+        self._matching = matching or {}
+        self._exclude = exclude or []
+
+    def matches(self, value: Any) -> bool:
+        return (
+            self._is_instance_matcher == value
+            and not (set(self._exclude) & set(value.keys()))
+            and self._matches_values(value)
+        )
+
+    def _matches_values(self, value: dict) -> bool:
+        for key, matcher in self._matching.items():
+            if key not in value or not matcher == value.get(key):
+                return False
+        return True
+
+    def __repr__(self):
+        exclude_repr = f"excluding {', '.join(map(repr, self._exclude))}" if self._exclude else ""
+        matching_reprs = [
+            f"expecting {repr(key)} {as_matcher(value).concatenated_repr()}"
+            for key, value in self._matching.items()
+        ]
+        return concat_reprs("To be a dictionary", exclude_repr, *matching_reprs)

--- a/src/pytest_matchers/tests/examples/test_example.py
+++ b/src/pytest_matchers/tests/examples/test_example.py
@@ -3,6 +3,7 @@ from random import random
 from unittest.mock import MagicMock
 
 from pytest_matchers import (
+    anything,
     between,
     case,
     different_value,
@@ -11,6 +12,7 @@ from pytest_matchers import (
     if_true,
     is_datetime,
     is_datetime_string,
+    is_dict,
     is_instance,
     is_list,
     is_number,
@@ -128,3 +130,42 @@ def test_conditional_matchers():
     assert 3 != matcher
     assert random() != matcher
     assert "10/11/2029" != matcher
+
+
+def test_compare_dictionaries():
+    test_dict = {"a": 1, "b": [2, "string"], "c": True, "d": "true"}
+
+    assert test_dict == {
+        "a": 1,
+        "b": is_list(length=2),
+        "c": True,
+        "d": anything(),
+    }
+    assert test_dict != {
+        "a": 1,
+        "b": is_list(length=2),
+        "c": True,
+    }
+    assert test_dict == is_dict(
+        {
+            "a": 1,
+            "b": is_list(length=2),
+            "c": True,
+        }
+    )
+    assert test_dict != is_dict(
+        {
+            "a": 1,
+            "b": is_list(length=2),
+            "c": True,
+        },
+        exclude=["d"],
+    )
+    assert test_dict == is_dict(
+        {
+            "a": 1,
+            "b": is_list(length=2),
+            "c": True,
+        },
+        exclude=["e"],
+    )

--- a/src/pytest_matchers/tests/matchers/test_dict.py
+++ b/src/pytest_matchers/tests/matchers/test_dict.py
@@ -1,0 +1,59 @@
+from pytest_matchers import anything, is_number, is_string
+from pytest_matchers.matchers import Dict
+
+
+def test_create():
+    matcher = Dict()
+    assert isinstance(matcher, Dict)
+    matcher = Dict({"key": 3})
+    assert isinstance(matcher, Dict)
+    matcher = Dict({"key": 3}, ["other"])
+    assert isinstance(matcher, Dict)
+
+
+def test_repr():
+    matcher = Dict()
+    assert repr(matcher) == "To be a dictionary"
+    matcher = Dict({"key": 3})
+    assert repr(matcher) == "To be a dictionary expecting 'key' to be 3"
+    matcher = Dict({"key": 3, "other": "string"})
+    assert (
+        repr(matcher)
+        == "To be a dictionary expecting 'key' to be 3 and expecting 'other' to be 'string'"
+    )
+    matcher = Dict(exclude=["key"])
+    assert repr(matcher) == "To be a dictionary excluding 'key'"
+    matcher = Dict({"key": 3}, ["other"])
+    assert repr(matcher) == "To be a dictionary excluding 'other' and expecting 'key' to be 3"
+    matcher = Dict({"key": is_string(), "any": anything(), "other": 3})
+    assert (
+        repr(matcher) == "To be a dictionary expecting 'key' to be string and "
+        "expecting 'any' to be anything and expecting 'other' to be 3"
+    )
+
+
+def test_matches():
+    matcher = Dict()
+    assert matcher == {}  # pylint: disable=use-implicit-booleaness-not-comparison
+    assert matcher == {"key": 3}
+    assert matcher != [1, 2, 3]
+    assert matcher != "string"
+    matcher = Dict({"key": 3})
+    assert matcher == {"key": 3}
+    assert matcher == {"key": 3, "other": 4}
+    assert matcher != {"key": 4}
+    assert matcher != {"other": 3}
+    matcher = Dict({"key": 3}, exclude=["other"])
+    assert matcher == {"key": 3}
+    assert matcher != {"key": 3, "other": 4}
+    assert matcher == {"key": 3, "x": 5}
+    matcher = Dict({"key": 3, "other": is_string()})
+    assert matcher == {"key": 3, "other": "string"}
+    assert matcher == {"key": 3, "other": "string", "x": [1, 2, 3]}
+    assert matcher != {"key": 3, "other": 4}
+    assert matcher != {"key": 3}
+    matcher = Dict({1: "one", 8.9: [1, 2, 3], "cool": is_number()})
+    assert matcher == {1: "one", 8.9: [1, 2, 3], "cool": 30.5}
+    assert matcher != {1: "one", 8.9: [1, 2, 3], False: "false"}
+    assert matcher == {1: "one", 8.9: [1, 2, 3], False: "false", "cool": 0}
+    assert matcher != {1: "one", 8.9: [1, 2, 3], "cool": "string"}

--- a/src/pytest_matchers/tests/test_main.py
+++ b/src/pytest_matchers/tests/test_main.py
@@ -11,6 +11,7 @@ from pytest_matchers import (
     if_true,
     is_datetime,
     is_datetime_string,
+    is_dict,
     is_instance,
     is_list,
     is_number,
@@ -188,3 +189,18 @@ def test_case():
     assert 4 != case(3, {3: is_string()}, 4)
     assert "string" == case(4, {3: is_number()}, is_string())
     assert 4 != case(4, {3: 3})
+
+
+def test_is_dict():
+    assert {"key": 3} == is_dict()
+    assert {"key": 3} == is_dict({"key": 3})
+    assert {"key": 3} != is_dict({"key": 4})
+    assert {"key": 3} != is_dict({"other": 3})
+    assert {"key": 3} == is_dict({"key": 3}, exclude=["other"])
+    assert {"key": 3, "other": 10} != is_dict({"key": 3}, exclude=["other"])
+    assert {"key": 3} != is_dict({"key": 3, "other": 4})
+    assert {"key": 3, "x": 5} == is_dict({"key": 3})
+    assert {"key": 3, "other": "string"} == is_dict({"key": 3, "other": is_string()})
+    assert {1: "one", 8.9: [1, 2, 3], "cool": 30.5} == is_dict(
+        {1: "one", 8.9: [1, 2, 3], "cool": is_number()}
+    )


### PR DESCRIPTION
Add support for dictionary comparison

```python
def test_compare_dictionaries():
    test_dict = {"a": 1, "b": [2, "string"], "c": True, "d": "true"}

    assert test_dict == {
        "a": 1,
        "b": is_list(length=2),
        "c": True,
        "d": anything(),
    }
    assert test_dict != {
        "a": 1,
        "b": is_list(length=2),
        "c": True,
    }
    assert test_dict == is_dict(
        {
            "a": 1,
            "b": is_list(length=2),
            "c": True,
        }
    )
    assert test_dict != is_dict(
        {
            "a": 1,
            "b": is_list(length=2),
            "c": True,
        },
        exclude=["d"],
    )
    assert test_dict == is_dict(
        {
            "a": 1,
            "b": is_list(length=2),
            "c": True,
        },
        exclude=["e"],
    )
```