### PR TITLE
feat: Add JSON matcher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ description = "Matchers for pytest"
 license = "MIT"
 authors = ["MartinGotelli <martingotelliferenaz@gmail.com>"]
 readme = "README.md"
+packages = [
+    { include = "pytest_matchers", from = "src/pytest_matchers" }
+]
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/src/pytest_matchers/pytest_matchers/__init__.py
+++ b/src/pytest_matchers/pytest_matchers/__init__.py
@@ -10,6 +10,7 @@ from .main import (
     is_datetime_string,
     is_dict,
     is_instance,
+    is_json,
     is_list,
     is_number,
     is_string,

--- a/src/pytest_matchers/pytest_matchers/main.py
+++ b/src/pytest_matchers/pytest_matchers/main.py
@@ -14,6 +14,7 @@ from pytest_matchers.matchers import (
     IsList,
     IsNumber,
     IsString,
+    JSON,
     Matcher,
     Or,
     SameValue,
@@ -115,5 +116,9 @@ def case(
     return Case(case_value, expectations, default_expectation)
 
 
-def is_dict(matching: dict = None, exclude: list[Any] = None) -> Dict:
-    return Dict(matching, exclude)
+def is_dict(matching: dict = None, *, exclude: list[Any] = None) -> Dict:
+    return Dict(matching, exclude=exclude)
+
+
+def is_json(matching: dict = None, *, exclude: list[Any] = None) -> JSON:
+    return JSON(matching, exclude=exclude)

--- a/src/pytest_matchers/pytest_matchers/matchers/__init__.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/__init__.py
@@ -3,10 +3,10 @@ from .length import Length
 from .contains import Contains
 from .starts_with import StartsWith
 from .ends_with import EndsWith
+from .eq import Eq
 from .between import Between
 
 from .and_matcher import And
-from .eq import Eq
 from .is_instance import IsInstance
 from .is_list import IsList
 from .is_string import IsString
@@ -22,3 +22,4 @@ from .different_value import DifferentValue
 from .if_matcher import If
 from .case import Case
 from .dict import Dict
+from .json import JSON

--- a/src/pytest_matchers/pytest_matchers/matchers/and_matcher.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/and_matcher.py
@@ -12,4 +12,4 @@ class And(Matcher):
         return all(matcher == value for matcher in self._matchers)
 
     def __repr__(self) -> str:
-        return concat_reprs("", *self._matchers)
+        return concat_reprs("", repr(self._matchers[0]), *self._matchers[1:])

--- a/src/pytest_matchers/pytest_matchers/matchers/base.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/base.py
@@ -27,5 +27,6 @@ class Matcher(ABC):
         pass
 
     def concatenated_repr(self) -> str:
-        base_repr = repr(self)
-        return base_repr[0].lower() + base_repr[1:]
+        from pytest_matchers.utils.repr_utils import non_capitalized
+
+        return non_capitalized(repr(self))

--- a/src/pytest_matchers/pytest_matchers/matchers/between.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/between.py
@@ -1,7 +1,7 @@
 from typing import Any
 
-from pytest_matchers.matchers import Matcher
-from pytest_matchers.utils.repr_utils import concat_reprs
+from pytest_matchers.matchers import Eq, Matcher
+from pytest_matchers.utils.repr_utils import concat_reprs, non_capitalized
 
 
 class Between(Matcher):
@@ -23,6 +23,11 @@ class Between(Matcher):
             min_inclusive, max_inclusive = inclusive, inclusive
         self._min_inclusive = min_inclusive or min_inclusive is None
         self._max_inclusive = max_inclusive or max_inclusive is None
+
+    def __new__(cls, min_value, max_value, inclusive=None, min_inclusive=None, max_inclusive=None):
+        if min_value is not None and min_value == max_value:
+            return Eq(min_value)
+        return super().__new__(cls)
 
     def matches(self, value: Any) -> bool:
         try:
@@ -53,7 +58,7 @@ class Between(Matcher):
         min_repr = self._min_repr()
         max_repr = self._max_repr()
         suffix = concat_reprs("", min_repr, max_repr)
-        return suffix[0].lower() + suffix[1:]
+        return non_capitalized(suffix)
 
     def __repr__(self) -> str:
         return f"To be {self._suffix_repr()}"

--- a/src/pytest_matchers/pytest_matchers/matchers/dict.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/dict.py
@@ -2,11 +2,11 @@ from typing import Any
 
 from pytest_matchers.matchers import IsInstance, Matcher
 from pytest_matchers.utils.matcher_utils import as_matcher
-from pytest_matchers.utils.repr_utils import concat_reprs
+from pytest_matchers.utils.repr_utils import concat_reprs, non_capitalized
 
 
 class Dict(Matcher):
-    def __init__(self, matching: dict = None, exclude: list[Any] = None):
+    def __init__(self, matching: dict = None, *, exclude: list = None):
         self._is_instance_matcher = IsInstance(dict)
         self._matching = matching or {}
         self._exclude = exclude or []
@@ -25,9 +25,18 @@ class Dict(Matcher):
         return True
 
     def __repr__(self):
+        return concat_reprs("To be a dictionary", self.expectations_repr())
+
+    def expectations_repr(self):
         exclude_repr = f"excluding {', '.join(map(repr, self._exclude))}" if self._exclude else ""
         matching_reprs = [
             f"expecting {repr(key)} {as_matcher(value).concatenated_repr()}"
             for key, value in self._matching.items()
         ]
-        return concat_reprs("To be a dictionary", exclude_repr, *matching_reprs)
+        return non_capitalized(concat_reprs("", exclude_repr, *matching_reprs))
+
+
+def dict_matcher(matching: dict | None, exclude: list | None) -> Dict | None:
+    if matching is None and exclude is None:
+        return None
+    return Dict(matching, exclude=exclude)

--- a/src/pytest_matchers/pytest_matchers/matchers/eq.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/eq.py
@@ -14,3 +14,6 @@ class Eq(Matcher):
 
     def __repr__(self) -> str:
         return f"To be {repr(self._match_value)}"
+
+    def concatenated_repr(self) -> str:
+        return f"equal to {repr(self._match_value)}"

--- a/src/pytest_matchers/pytest_matchers/matchers/if_matcher.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/if_matcher.py
@@ -41,7 +41,7 @@ class If(Matcher):
             return repr(self._or_else)
 
         representation = (
-            f"{self._then.concatenated_repr()} if condition returns True"
+            f"{repr(self._then)} if condition returns True"
             f" else {self._or_else.concatenated_repr()}"
         )
         return capitalized(representation)

--- a/src/pytest_matchers/pytest_matchers/matchers/is_string.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/is_string.py
@@ -38,7 +38,7 @@ class IsString(Matcher):
 
     def __repr__(self) -> str:
         return concat_reprs(
-            "To be string",
+            "To be a string",
             self._length_matcher,
             self._contains_matcher,
             self._starts_with_matcher,

--- a/src/pytest_matchers/pytest_matchers/matchers/json.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/json.py
@@ -1,0 +1,26 @@
+import json
+from typing import Any
+
+from pytest_matchers.matchers import IsInstance, Matcher
+from pytest_matchers.matchers.dict import dict_matcher
+from pytest_matchers.utils.matcher_utils import matches_or_none
+from pytest_matchers.utils.repr_utils import concat_reprs
+
+
+class JSON(Matcher):
+    def __init__(self, matching: dict = None, *, exclude: list = None):
+        self._is_instance_matcher = IsInstance(str)
+        self._dict_matcher = dict_matcher(matching, exclude)
+
+    def matches(self, value: Any) -> bool:
+        if self._is_instance_matcher == value:
+            try:
+                json_data = json.loads(value)
+            except json.JSONDecodeError:
+                return False
+            return matches_or_none(self._dict_matcher, json_data)
+        return False
+
+    def __repr__(self) -> str:
+        dict_repr = self._dict_matcher.expectations_repr() if self._dict_matcher else ""
+        return concat_reprs("To be a JSON", dict_repr)

--- a/src/pytest_matchers/pytest_matchers/matchers/not_matcher.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/not_matcher.py
@@ -20,4 +20,4 @@ class Not(Matcher):
         return not self._matcher == value
 
     def __repr__(self) -> str:
-        return f"Not {self._matcher.concatenated_repr()}"
+        return f"To not be {self._matcher.concatenated_repr()}"

--- a/src/pytest_matchers/pytest_matchers/matchers/or_matcher.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/or_matcher.py
@@ -12,4 +12,4 @@ class Or(Matcher):
         return any(matcher == value for matcher in self._matchers)
 
     def __repr__(self) -> str:
-        return concat_reprs("", *self._matchers, separator="or")
+        return concat_reprs("", repr(self._matchers[0]), *self._matchers[1:], separator="or")

--- a/src/pytest_matchers/pytest_matchers/utils/repr_utils.py
+++ b/src/pytest_matchers/pytest_matchers/utils/repr_utils.py
@@ -12,10 +12,11 @@ def concat_matcher_repr(matcher: Matcher | None) -> str:
 
 
 def concat_reprs(
-    base_repr: str | None,
+    base_repr: str | Matcher | None,
     *extra_reprs: str | Matcher | None,
     separator: str = "and",
 ) -> str:
+    base_repr = str(base_repr) if base_repr else ""
     extra_repr = f" {separator} ".join(
         [_repr(extra_repr) for extra_repr in extra_reprs if extra_repr]
     )
@@ -27,4 +28,12 @@ def concat_reprs(
 
 
 def capitalized(string: str):
+    if not string:
+        return string
     return string[0].upper() + string[1:]
+
+
+def non_capitalized(string: str):
+    if not string:
+        return string
+    return string[0].lower() + string[1:]

--- a/src/pytest_matchers/tests/matchers/test_and.py
+++ b/src/pytest_matchers/tests/matchers/test_and.py
@@ -14,7 +14,7 @@ def test_repr():
     matcher = And(Eq(1))
     assert repr(matcher) == "To be 1"
     matcher = IsInstance(int) & Eq(1)
-    assert repr(matcher) == "Of 'int' instance and to be 1"
+    assert repr(matcher) == "To be instance of 'int' and equal to 1"
 
 
 def test_matches():

--- a/src/pytest_matchers/tests/matchers/test_between.py
+++ b/src/pytest_matchers/tests/matchers/test_between.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pytest_matchers.matchers import Between
+from pytest_matchers.matchers import Between, Eq
 
 
 def test_create():
@@ -12,6 +12,8 @@ def test_create():
     assert isinstance(matcher, Between)
     matcher = Between(1, 2, max_inclusive=False)
     assert isinstance(matcher, Between)
+    matcher = Between(1, 1)
+    assert isinstance(matcher, Eq)
     with pytest.raises(
         ValueError,
         match="Cannot specify inclusive and min_inclusive or max_inclusive",
@@ -37,6 +39,8 @@ def test_repr():
     assert repr(matcher) == "To be greater or equal than 1"
     matcher = Between(None, 2, max_inclusive=False)
     assert repr(matcher) == "To be lower than 2"
+    matcher = Between(1, 1)
+    assert repr(matcher) == "To be 1"
 
 
 def test_concatenated_repr():
@@ -52,6 +56,8 @@ def test_concatenated_repr():
     assert matcher.concatenated_repr() == "greater or equal than 1"
     matcher = Between(None, 2, max_inclusive=False)
     assert matcher.concatenated_repr() == "lower than 2"
+    matcher = Between(1, 1)
+    assert matcher.concatenated_repr() == "equal to 1"
 
 
 def test_matches_float_inclusive():

--- a/src/pytest_matchers/tests/matchers/test_case.py
+++ b/src/pytest_matchers/tests/matchers/test_case.py
@@ -23,7 +23,7 @@ def test_repr():
     matcher = Case(4, {3: 4}, 5)
     assert repr(matcher) == "To be 5 because case value is 4"
     matcher = Case(4, {3: 3}, is_string())
-    assert repr(matcher) == "To be string because case value is 4"
+    assert repr(matcher) == "To be a string because case value is 4"
     matcher = Case(4, {3: 3})
     assert (
         repr(matcher) == "To never match because case value 4 is not expected "

--- a/src/pytest_matchers/tests/matchers/test_dict.py
+++ b/src/pytest_matchers/tests/matchers/test_dict.py
@@ -7,7 +7,7 @@ def test_create():
     assert isinstance(matcher, Dict)
     matcher = Dict({"key": 3})
     assert isinstance(matcher, Dict)
-    matcher = Dict({"key": 3}, ["other"])
+    matcher = Dict({"key": 3}, exclude=["other"])
     assert isinstance(matcher, Dict)
 
 
@@ -15,20 +15,20 @@ def test_repr():
     matcher = Dict()
     assert repr(matcher) == "To be a dictionary"
     matcher = Dict({"key": 3})
-    assert repr(matcher) == "To be a dictionary expecting 'key' to be 3"
+    assert repr(matcher) == "To be a dictionary expecting 'key' equal to 3"
     matcher = Dict({"key": 3, "other": "string"})
     assert (
         repr(matcher)
-        == "To be a dictionary expecting 'key' to be 3 and expecting 'other' to be 'string'"
+        == "To be a dictionary expecting 'key' equal to 3 and expecting 'other' equal to 'string'"
     )
     matcher = Dict(exclude=["key"])
     assert repr(matcher) == "To be a dictionary excluding 'key'"
-    matcher = Dict({"key": 3}, ["other"])
-    assert repr(matcher) == "To be a dictionary excluding 'other' and expecting 'key' to be 3"
+    matcher = Dict({"key": 3}, exclude=["other"])
+    assert repr(matcher) == "To be a dictionary excluding 'other' and expecting 'key' equal to 3"
     matcher = Dict({"key": is_string(), "any": anything(), "other": 3})
     assert (
-        repr(matcher) == "To be a dictionary expecting 'key' to be string and "
-        "expecting 'any' to be anything and expecting 'other' to be 3"
+        repr(matcher) == "To be a dictionary expecting 'key' to be a string and "
+        "expecting 'any' to be anything and expecting 'other' equal to 3"
     )
 
 

--- a/src/pytest_matchers/tests/matchers/test_eq.py
+++ b/src/pytest_matchers/tests/matchers/test_eq.py
@@ -16,3 +16,8 @@ def test_matches():
 def test_repr():
     assert repr(Eq(1)) == "To be 1"
     assert repr(Eq("string")) == "To be 'string'"
+
+
+def test_concatenated_repr():
+    assert Eq(1).concatenated_repr() == "equal to 1"
+    assert Eq("string").concatenated_repr() == "equal to 'string'"

--- a/src/pytest_matchers/tests/matchers/test_has_attribute.py
+++ b/src/pytest_matchers/tests/matchers/test_has_attribute.py
@@ -21,11 +21,11 @@ def test_repr():
     matcher = HasAttribute("attribute_name")
     assert repr(matcher) == "To have attribute 'attribute_name'"
     matcher = HasAttribute("attribute_name", "expected_value")
-    assert repr(matcher) == "To have attribute 'attribute_name' and to be 'expected_value'"
+    assert repr(matcher) == "To have attribute 'attribute_name' and equal to 'expected_value'"
     matcher = HasAttribute("attribute_name", 42)
-    assert repr(matcher) == "To have attribute 'attribute_name' and to be 42"
+    assert repr(matcher) == "To have attribute 'attribute_name' and equal to 42"
     matcher = HasAttribute("attribute_name", is_string())
-    assert repr(matcher) == "To have attribute 'attribute_name' and to be string"
+    assert repr(matcher) == "To have attribute 'attribute_name' and to be a string"
 
 
 def test_concatenated_repr():
@@ -36,7 +36,7 @@ def test_concatenated_repr():
     matcher = HasAttribute("attribute_name", 42)
     assert matcher.concatenated_repr() == "with 'attribute_name' being 42"
     matcher = HasAttribute("attribute_name", is_string())
-    assert matcher.concatenated_repr() == "with 'attribute_name' expecting to be string"
+    assert matcher.concatenated_repr() == "with 'attribute_name' expecting to be a string"
 
 
 def test_matches():

--- a/src/pytest_matchers/tests/matchers/test_if.py
+++ b/src/pytest_matchers/tests/matchers/test_if.py
@@ -27,9 +27,9 @@ def test_repr():
     matcher = If(lambda x: x == 3, 3)
     assert repr(matcher) == "To be 3 if condition returns True else to be anything"
     matcher = If(lambda x: x == 3, is_number(), 4)
-    assert repr(matcher) == "To be a number if condition returns True else to be 4"
+    assert repr(matcher) == "To be a number if condition returns True else equal to 4"
     matcher = If(lambda x: x == 3, or_else=is_string())
-    assert repr(matcher) == "To be anything if condition returns True else to be string"
+    assert repr(matcher) == "To be anything if condition returns True else to be a string"
 
 
 def test_match():

--- a/src/pytest_matchers/tests/matchers/test_is_number.py
+++ b/src/pytest_matchers/tests/matchers/test_is_number.py
@@ -34,6 +34,8 @@ def test_repr():
     assert repr(matcher) == "To be a number greater or equal than 1 and lower than 2"
     matcher = IsNumber(float, min_value=1, max_value=2)
     assert repr(matcher) == "To be a number of 'float' instance and between 1 and 2"
+    matcher = IsNumber(min_value=1, max_value=1)
+    assert repr(matcher) == "To be a number equal to 1"
 
 
 def test_matches_number():

--- a/src/pytest_matchers/tests/matchers/test_is_string.py
+++ b/src/pytest_matchers/tests/matchers/test_is_string.py
@@ -20,17 +20,17 @@ def test_create():
 
 def test_repr():
     matcher = IsString()
-    assert repr(matcher) == "To be string"
+    assert repr(matcher) == "To be a string"
     matcher = IsString(contains="ab")
-    assert repr(matcher) == "To be string containing 'ab'"
+    assert repr(matcher) == "To be a string containing 'ab'"
     matcher = IsString(starts_with="ab")
-    assert repr(matcher) == "To be string starting with 'ab'"
+    assert repr(matcher) == "To be a string starting with 'ab'"
     matcher = IsString(ends_with="bc")
-    assert repr(matcher) == "To be string ending with 'bc'"
+    assert repr(matcher) == "To be a string ending with 'bc'"
     matcher = IsString(length=1)
-    assert repr(matcher) == "To be string with length of 1"
+    assert repr(matcher) == "To be a string with length of 1"
     matcher = IsString(min_length=1, max_length=3)
-    assert repr(matcher) == "To be string with length between 1 and 3"
+    assert repr(matcher) == "To be a string with length between 1 and 3"
     matcher = IsString(
         contains="ab",
         starts_with="ab",
@@ -39,7 +39,7 @@ def test_repr():
         max_length=8,
     )
     assert (
-        repr(matcher) == "To be string with length between 1 and 8 and containing 'ab'"
+        repr(matcher) == "To be a string with length between 1 and 8 and containing 'ab'"
         " and starting with 'ab' and ending with 'bc'"
     )
 

--- a/src/pytest_matchers/tests/matchers/test_json.py
+++ b/src/pytest_matchers/tests/matchers/test_json.py
@@ -1,0 +1,73 @@
+from pytest_matchers import is_number, is_string
+from pytest_matchers.matchers import JSON
+
+
+def test_create():
+    matcher = JSON()
+    assert isinstance(matcher, JSON)
+    matcher = JSON({})
+    assert isinstance(matcher, JSON)
+    matcher = JSON({"key": 4})
+    assert isinstance(matcher, JSON)
+    matcher = JSON(exclude=["key"])
+    assert isinstance(matcher, JSON)
+    matcher = JSON({"key": 4}, exclude=["key"])
+    assert isinstance(matcher, JSON)
+
+
+def test_repr():
+    matcher = JSON()
+    assert repr(matcher) == "To be a JSON"
+    matcher = JSON({"key": 4})
+    assert repr(matcher) == "To be a JSON expecting 'key' equal to 4"
+    matcher = JSON({"key": 4, "other": "string"})
+    assert (
+        repr(matcher)
+        == "To be a JSON expecting 'key' equal to 4 and expecting 'other' equal to 'string'"
+    )
+    matcher = JSON(exclude=["key"])
+    assert repr(matcher) == "To be a JSON excluding 'key'"
+    matcher = JSON({"key": 4}, exclude=["other"])
+    assert repr(matcher) == "To be a JSON excluding 'other' and expecting 'key' equal to 4"
+    matcher = JSON({"string": is_string(), "number": is_number()})
+    assert (
+        repr(matcher)
+        == "To be a JSON expecting 'string' to be a string and expecting 'number' to be a number"
+    )
+
+
+def test_matches():
+    matcher = JSON()
+    assert matcher == "{}"
+    assert matcher == '{"key": 4}'
+    assert matcher == '{"key": 4, "other": "string"}'
+    assert matcher == '{"key": 4, "other": "string", "extra": 5}'
+    assert matcher != "string"
+    assert matcher != "{'key': 4}"
+    assert matcher != ""
+    assert matcher != {"key": 4}
+    assert matcher != 3
+
+    matcher = JSON({"key": 4})
+    assert matcher == '{"key": 4}'
+    assert matcher == '{"key": 4, "other": "string"}'
+    assert matcher != '{"key": 5}'
+    assert matcher != {"key": 4}
+
+    matcher = JSON(exclude=["key"])
+    assert matcher == '{"other": "string"}'
+    assert matcher != '{"key": 4}'
+    assert matcher != '{"key": 4, "other": "string"}'
+
+    matcher = JSON({"key": 4, "other": "string"}, exclude=["extra"])
+    assert matcher == '{"key": 4, "other": "string"}'
+    assert matcher != '{"key": 5, "other": "string"}'
+    assert matcher != '{"key": 4, "other": "string", "extra": 5}'
+    assert matcher != '{"key": 4, "extra": 5}'
+
+    matcher = JSON({"string": is_string(), "number": is_number()})
+    assert matcher == '{"string": "string", "number": 3}'
+    assert matcher == '{"string": "string", "number": 3, "extra": 5}'
+    assert matcher != '{"string": 4, "number": 3}'
+    assert matcher != '{"string": "string", "number": "string"}'
+    assert matcher != '{"string": "string"}'

--- a/src/pytest_matchers/tests/matchers/test_not.py
+++ b/src/pytest_matchers/tests/matchers/test_not.py
@@ -12,13 +12,13 @@ def test_create():
 
 def test_repr():
     matcher = Not(Eq(1))
-    assert repr(matcher) == "Not to be 1"
+    assert repr(matcher) == "To not be equal to 1"
     matcher = ~Eq(1)
-    assert repr(matcher) == "Not to be 1"
+    assert repr(matcher) == "To not be equal to 1"
     matcher = Not(6)
-    assert repr(matcher) == "Not to be 6"
+    assert repr(matcher) == "To not be equal to 6"
     matcher = Not(IsInstance(int))
-    assert repr(matcher) == "Not of 'int' instance"
+    assert repr(matcher) == "To not be of 'int' instance"
     matcher = Not(Not(IsInstance(int)))
     assert repr(matcher) == repr(IsInstance(int))
 

--- a/src/pytest_matchers/tests/matchers/test_or.py
+++ b/src/pytest_matchers/tests/matchers/test_or.py
@@ -14,7 +14,7 @@ def test_repr():
     matcher = Or(Eq(1))
     assert repr(matcher) == "To be 1"
     matcher = IsInstance(int) | Eq(1)
-    assert repr(matcher) == "Of 'int' instance or to be 1"
+    assert repr(matcher) == "To be instance of 'int' or equal to 1"
 
 
 def test_matches():

--- a/src/pytest_matchers/tests/test_main.py
+++ b/src/pytest_matchers/tests/test_main.py
@@ -13,6 +13,7 @@ from pytest_matchers import (
     is_datetime_string,
     is_dict,
     is_instance,
+    is_json,
     is_list,
     is_number,
     is_string,
@@ -204,3 +205,15 @@ def test_is_dict():
     assert {1: "one", 8.9: [1, 2, 3], "cool": 30.5} == is_dict(
         {1: "one", 8.9: [1, 2, 3], "cool": is_number()}
     )
+
+
+def test_is_json():
+    assert "{}" == is_json()
+    assert '{"key": "value"}' == is_json()
+    assert '{"key": 4}' == is_json({"key": 4})
+    assert '{"key": 4}' != is_json({"key": 5})
+    assert '{"key": 4, "other": 10}' == is_json({"key": 4})
+    assert '{"key": 4}' != is_json({"other": 4})
+    assert '{"key": 4}' == is_json({"key": 4}, exclude=["other"])
+    assert '{"key": 4, "other": 10}' != is_json({"key": 4}, exclude=["other"])
+    assert '{"key": 4, "other": "string"}' == is_json({"key": 4, "other": is_string()})

--- a/src/pytest_matchers/tests/utils/test_repr_utils.py
+++ b/src/pytest_matchers/tests/utils/test_repr_utils.py
@@ -1,29 +1,45 @@
 from pytest_matchers.matchers import Eq, IsInstance
-from pytest_matchers.utils.repr_utils import capitalized, concat_matcher_repr, concat_reprs
+from pytest_matchers.utils.repr_utils import (
+    capitalized,
+    concat_matcher_repr,
+    concat_reprs,
+    non_capitalized,
+)
 
 
 def test_concat_matcher_repr():
     matcher = IsInstance(str)
     assert concat_matcher_repr(matcher) == "of 'str' instance"
     matcher = Eq(3)
-    assert concat_matcher_repr(matcher) == "to be 3"
+    assert concat_matcher_repr(matcher) == "equal to 3"
     matcher = None
     assert concat_matcher_repr(matcher) is None
 
 
 def test_concat_reprs():
-    assert concat_reprs(None) is None
+    assert concat_reprs(None) == ""
     assert concat_reprs("I expect") == "I expect"
-    assert concat_reprs("I expect", Eq(3)) == "I expect to be 3"
-    assert concat_reprs("I expect", Eq(3), Eq(4)) == "I expect to be 3 and to be 4"
+    assert concat_reprs("I expect", Eq(3)) == "I expect equal to 3"
+    assert concat_reprs("I expect", Eq(3), Eq(4)) == "I expect equal to 3 and equal to 4"
     assert (
         concat_reprs("I expect", IsInstance(str), Eq(2), "be happy")
-        == "I expect of 'str' instance and to be 2 and be happy"
+        == "I expect of 'str' instance and equal to 2 and be happy"
     )
-    assert concat_reprs("I expect", Eq(3), Eq(4), separator="or") == "I expect to be 3 or to be 4"
+    assert (
+        concat_reprs("I expect", Eq(3), Eq(4), separator="or")
+        == "I expect equal to 3 or equal to 4"
+    )
 
 
 def test_capitalized():
     assert capitalized("i expect") == "I expect"
     assert capitalized("I expect") == "I expect"
     assert capitalized("I KNOW") == "I KNOW"
+    assert capitalized("") == ""
+
+
+def test_non_capitalized():
+    assert non_capitalized("i expect") == "i expect"
+    assert non_capitalized("I expect") == "i expect"
+    assert non_capitalized("I KNOW") == "i KNOW"
+    assert non_capitalized("") == ""


### PR DESCRIPTION
Add a new JSON string matcher:
```python
def test_is_json():
    assert "{}" == is_json()
    assert '{"key": "value"}' == is_json()
    assert '{"key": 4}' == is_json({"key": 4})
    assert '{"key": 4}' != is_json({"key": 5})
    assert '{"key": 4, "other": 10}' == is_json({"key": 4})
    assert '{"key": 4}' != is_json({"other": 4})
    assert '{"key": 4}' == is_json({"key": 4}, exclude=["other"])
    assert '{"key": 4, "other": 10}' != is_json({"key": 4}, exclude=["other"])
    assert '{"key": 4, "other": "string"}' == is_json({"key": 4, "other": is_string()})
```