### PR TITLE
feat: Add strict dict matcher

### DIFF
--- a/src/pytest_matchers/pytest_matchers/__init__.py
+++ b/src/pytest_matchers/pytest_matchers/__init__.py
@@ -13,6 +13,7 @@ from .main import (
     is_json,
     is_list,
     is_number,
+    is_strict_dict,
     is_string,
     one_of,
     same_value,

--- a/src/pytest_matchers/pytest_matchers/main.py
+++ b/src/pytest_matchers/pytest_matchers/main.py
@@ -18,6 +18,7 @@ from pytest_matchers.matchers import (
     Matcher,
     Or,
     SameValue,
+    StrictDict,
 )
 
 
@@ -118,6 +119,21 @@ def case(
 
 def is_dict(matching: dict = None, *, exclude: list[Any] = None) -> Dict:
     return Dict(matching, exclude=exclude)
+
+
+def is_strict_dict(
+    matching: dict,
+    *,
+    extra_condition: bool = None,
+    when_true: dict = None,
+    when_false: dict = None,
+) -> StrictDict:
+    return StrictDict(
+        matching,
+        extra_condition=extra_condition,
+        when_true=when_true,
+        when_false=when_false,
+    )
 
 
 def is_json(matching: dict = None, *, exclude: list[Any] = None) -> JSON:

--- a/src/pytest_matchers/pytest_matchers/matchers/__init__.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/__init__.py
@@ -23,3 +23,4 @@ from .if_matcher import If
 from .case import Case
 from .dict import Dict
 from .json import JSON
+from .strict_dict import StrictDict

--- a/src/pytest_matchers/pytest_matchers/matchers/dict.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/dict.py
@@ -24,7 +24,7 @@ class Dict(Matcher):
                 return False
         return True
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return concat_reprs("To be a dictionary", self.expectations_repr())
 
     def expectations_repr(self):

--- a/src/pytest_matchers/pytest_matchers/matchers/strict_dict.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/strict_dict.py
@@ -1,0 +1,47 @@
+from typing import Any
+
+from pytest_matchers.matchers import IsInstance, Matcher
+from pytest_matchers.utils.matcher_utils import as_matcher
+from pytest_matchers.utils.repr_utils import concat_reprs, non_capitalized
+
+
+class StrictDict(Matcher):
+    def __init__(
+        self,
+        matching: dict,
+        *,
+        extra_condition: bool = None,
+        when_true: dict = None,
+        when_false: dict = None,
+    ):
+        self._is_instance_matcher = IsInstance(dict)
+        self._matching = matching
+        if (when_true or when_false) and extra_condition is None:
+            raise ValueError("extra_condition must be set when using when_true or when_false")
+        self._extra_condition = extra_condition
+        self._when_true = when_true or {}
+        self._when_false = when_false or {}
+
+    def matches(self, value: Any) -> bool:
+        return self._is_instance_matcher == value and self._expected_dictionary() == value
+
+    def _expected_dictionary(self) -> dict:
+        expected_value = self._matching
+        if self._extra_condition is not None:
+            if self._extra_condition:
+                expected_value |= self._when_true
+            else:
+                expected_value |= self._when_false
+        return expected_value
+
+    def __repr__(self) -> str:
+        if self._expected_dictionary() == {}:
+            return "To be an empty dictionary"
+        return concat_reprs("To be a dictionary", self.expectations_repr())
+
+    def expectations_repr(self):
+        matching_reprs = [
+            f"expecting {repr(key)} {as_matcher(value).concatenated_repr()}"
+            for key, value in self._expected_dictionary().items()
+        ]
+        return non_capitalized(concat_reprs("only", *matching_reprs))

--- a/src/pytest_matchers/tests/examples/test_example.py
+++ b/src/pytest_matchers/tests/examples/test_example.py
@@ -16,6 +16,7 @@ from pytest_matchers import (
     is_instance,
     is_list,
     is_number,
+    is_strict_dict,
     is_string,
     same_value,
 )
@@ -168,4 +169,25 @@ def test_compare_dictionaries():
             "c": True,
         },
         exclude=["e"],
+    )
+
+
+def test_compare_strict_dictionaries():
+    def _condition(value):
+        return value == is_string()
+
+    test_dict = {"a": 1, "b": [2, "string"], "c": True}
+    assert test_dict == is_strict_dict({"a": 1, "b": [2, "string"], "c": True})
+    assert test_dict != is_strict_dict({"a": 1, "b": [2, "string"]})
+    assert test_dict == is_strict_dict(
+        {"a": 1, "b": [2, "string"]},
+        extra_condition=_condition("string"),
+        when_true={"c": True},
+        when_false={"c": False},
+    )
+    assert test_dict != is_strict_dict(
+        {"a": 1, "b": [2, "string"]},
+        extra_condition=_condition(10),
+        when_true={"c": True},
+        when_false={"c": False},
     )

--- a/src/pytest_matchers/tests/matchers/test_strict_dict.py
+++ b/src/pytest_matchers/tests/matchers/test_strict_dict.py
@@ -1,0 +1,86 @@
+import pytest
+
+from pytest_matchers import is_number, is_string
+from pytest_matchers.matchers import StrictDict
+
+
+def test_create():
+    matcher = StrictDict({})
+    assert isinstance(matcher, StrictDict)
+    matcher = StrictDict({"a": "b"})
+    assert isinstance(matcher, StrictDict)
+    matcher = StrictDict({}, extra_condition=True, when_true={"a": 1}, when_false={"b": 2})
+    assert isinstance(matcher, StrictDict)
+    matcher = StrictDict({}, extra_condition=False, when_true={"a": 1})
+    assert isinstance(matcher, StrictDict)
+    matcher = StrictDict({}, extra_condition=False, when_false={"b": 2})
+    assert isinstance(matcher, StrictDict)
+    with pytest.raises(
+        ValueError,
+        match="extra_condition must be set when using when_true or when_false",
+    ):
+        StrictDict({}, when_true={"a": 1})
+
+
+def test_repr():
+    matcher = StrictDict({})
+    assert repr(matcher) == "To be an empty dictionary"
+    matcher = StrictDict({"a": "b"})
+    assert repr(matcher) == "To be a dictionary only expecting 'a' equal to 'b'"
+    matcher = StrictDict({}, extra_condition=True, when_true={"a": 1}, when_false={"b": 2})
+    assert repr(matcher) == "To be a dictionary only expecting 'a' equal to 1"
+    matcher = StrictDict({}, extra_condition=False, when_true={"a": 1})
+    assert repr(matcher) == "To be an empty dictionary"
+    matcher = StrictDict({}, extra_condition=False, when_false={"b": 2})
+    assert repr(matcher) == "To be a dictionary only expecting 'b' equal to 2"
+    matcher = StrictDict({"x": 3, 2: True}, extra_condition=True, when_true={"a": 1})
+    assert (
+        repr(matcher) == "To be a dictionary only expecting 'x' equal to 3 and "
+        "expecting 2 equal to True and expecting 'a' equal to 1"
+    )
+
+
+def test_matches():
+    matcher = StrictDict({})
+    assert matcher == {}  # pylint: disable=use-implicit-booleaness-not-comparison
+    assert matcher != {"a": 1}
+    assert matcher != 9
+    matcher = StrictDict({"a": 1})
+    assert matcher == {"a": 1}
+    assert matcher != {"a": 2}
+    assert matcher != {"b": 1}
+    matcher = StrictDict({"a": 1, "b": 2})
+    assert matcher == {"a": 1, "b": 2}
+    assert matcher != {"a": 2, "b": 1}
+    assert matcher != {"a": 1}
+    assert matcher != {"b": 2}
+    matcher = StrictDict({"a": 1}, extra_condition=True, when_true={"b": 2})
+    assert matcher == {"a": 1, "b": 2}
+    assert matcher != {"a": 1}
+    assert matcher != {"b": 2}
+    assert matcher != {"a": 1, "b": 1}
+    matcher = StrictDict({"a": 1}, extra_condition=False, when_true={"c": 3}, when_false={"b": 2})
+    assert matcher == {"a": 1, "b": 2}
+    assert matcher != {"a": 1}
+    assert matcher != {"a": 1, "c": 3}
+    matcher = StrictDict(
+        {"a": 1, "b": 2},
+        extra_condition=True,
+        when_true={"c": 3},
+        when_false={"b": 2},
+    )
+    assert matcher == {"a": 1, "b": 2, "c": 3}
+    assert matcher != {"a": 1, "b": 2}
+    assert matcher != {"a": 1, "c": 3}
+    assert matcher != {"b": 2, "c": 3}
+    matcher = StrictDict({"a": 1, "b": 2}, extra_condition=False, when_true={"c": 3})
+    assert matcher == {"a": 1, "b": 2}
+    assert matcher != {"a": 1, "b": 2, "c": 3}
+    matcher = StrictDict(
+        {"a": 1},
+        extra_condition=True,
+        when_true={"b": is_string()},
+        when_false={"b": is_number()},
+    )
+    assert matcher == {"a": 1, "b": "string"}
+    assert matcher != {"a": 1, "b": 2}

--- a/src/pytest_matchers/tests/test_main.py
+++ b/src/pytest_matchers/tests/test_main.py
@@ -16,6 +16,7 @@ from pytest_matchers import (
     is_json,
     is_list,
     is_number,
+    is_strict_dict,
     is_string,
     one_of,
     same_value,
@@ -205,6 +206,32 @@ def test_is_dict():
     assert {1: "one", 8.9: [1, 2, 3], "cool": 30.5} == is_dict(
         {1: "one", 8.9: [1, 2, 3], "cool": is_number()}
     )
+
+
+def test_is_strict_dict():
+    assert {"key": 3} != is_strict_dict({})
+    assert {"key": 3} == is_strict_dict({"key": 3})
+    assert {"key": 3} != is_strict_dict({"key": 4})
+    assert {"key": 3, "other": 5} != is_strict_dict({"key": 3})
+    assert {"key": 3, "other": 4} == is_strict_dict(
+        {"key": 3},
+        extra_condition=True,
+        when_true={"other": 4},
+        when_false={"other": 5},
+    )
+    assert {"key": 3, "other": 4} != is_strict_dict(
+        {"key": 3},
+        extra_condition=False,
+        when_true={"other": 4},
+        when_false={"other": 5},
+    )
+    assert {"key": "hey"} != is_strict_dict(
+        {},
+        extra_condition=False,
+        when_true={"key": is_string()},
+    )
+    # pylint: disable=use-implicit-booleaness-not-comparison
+    assert {} == is_strict_dict({}, extra_condition=False, when_true={"key": is_string()})
 
 
 def test_is_json():


### PR DESCRIPTION
Adds strict dict matcher:
```python
def test_compare_strict_dictionaries():
    def _condition(value):
        return value == is_string()

    test_dict = {"a": 1, "b": [2, "string"], "c": True}
    assert test_dict == is_strict_dict({"a": 1, "b": [2, "string"], "c": True})
    assert test_dict != is_strict_dict({"a": 1, "b": [2, "string"]})
    assert test_dict == is_strict_dict(
        {"a": 1, "b": [2, "string"]},
        extra_condition=_condition("string"),
        when_true={"c": True},
        when_false={"c": False},
    )
    assert test_dict != is_strict_dict(
        {"a": 1, "b": [2, "string"]},
        extra_condition=_condition(10),
        when_true={"c": True},
        when_false={"c": False},
    )
```