### PR TITLE
feat: Add is_uuid matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ Actual   :0.9048172867693559
 - `if_true`
 - `if_false`
 - `case`
+- `is_dict`
+- `is_strict_dict`
+- `is_json`
+- `is_uuid`

--- a/src/pytest_matchers/pytest_matchers/__init__.py
+++ b/src/pytest_matchers/pytest_matchers/__init__.py
@@ -15,6 +15,7 @@ from .main import (
     is_number,
     is_strict_dict,
     is_string,
+    is_uuid,
     one_of,
     same_value,
 )

--- a/src/pytest_matchers/pytest_matchers/main.py
+++ b/src/pytest_matchers/pytest_matchers/main.py
@@ -19,6 +19,7 @@ from pytest_matchers.matchers import (
     Or,
     SameValue,
     StrictDict,
+    UUID,
 )
 
 
@@ -138,3 +139,7 @@ def is_strict_dict(
 
 def is_json(matching: dict = None, *, exclude: list[Any] = None) -> JSON:
     return JSON(matching, exclude=exclude)
+
+
+def is_uuid(matching_type: Type = None, *, version: int | Matcher = None) -> UUID:
+    return UUID(matching_type, version=version)

--- a/src/pytest_matchers/pytest_matchers/matchers/__init__.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/__init__.py
@@ -24,3 +24,4 @@ from .case import Case
 from .dict import Dict
 from .json import JSON
 from .strict_dict import StrictDict
+from .uuid import UUID

--- a/src/pytest_matchers/pytest_matchers/matchers/uuid.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/uuid.py
@@ -1,0 +1,35 @@
+import uuid
+from typing import Any, Type
+
+from pytest_matchers.matchers import Matcher
+from pytest_matchers.utils.matcher_utils import (
+    as_matcher_or_none,
+    is_instance_matcher,
+    matches_or_none,
+)
+from pytest_matchers.utils.repr_utils import concat_matcher_repr, concat_reprs
+
+
+class UUID(Matcher):
+    def __init__(self, matching_type: Type = None, *, version: int | Matcher = None):
+        self._is_instance_matcher = is_instance_matcher(matching_type)
+        self._version_matcher = as_matcher_or_none(version)
+
+    def matches(self, value: Any) -> bool:
+        if matches_or_none(self._is_instance_matcher, value):
+            try:
+                uuid_value = uuid.UUID(str(value))
+                return matches_or_none(self._version_matcher, uuid_value.version)
+            except ValueError:
+                pass
+        return False
+
+    def __repr__(self) -> str:
+        base_repr = "To be a UUID"
+        instance_matcher_repr = concat_matcher_repr(self._is_instance_matcher) or ""
+        version_matcher_repr = (
+            f"with version {concat_matcher_repr(self._version_matcher)}"
+            if self._version_matcher
+            else ""
+        )
+        return concat_reprs(f"{base_repr}", instance_matcher_repr, version_matcher_repr)

--- a/src/pytest_matchers/pytest_matchers/utils/repr_utils.py
+++ b/src/pytest_matchers/pytest_matchers/utils/repr_utils.py
@@ -1,10 +1,12 @@
+from typing import Any
+
 from pytest_matchers.matchers import Matcher
 
 
-def _repr(extra_repr: str | Matcher | None) -> str:
+def _repr(extra_repr: Any | Matcher | None) -> str:
     if isinstance(extra_repr, Matcher):
         return extra_repr.concatenated_repr()
-    return extra_repr
+    return str(extra_repr) if extra_repr is not None else ""
 
 
 def concat_matcher_repr(matcher: Matcher | None) -> str:

--- a/src/pytest_matchers/tests/examples/test_example.py
+++ b/src/pytest_matchers/tests/examples/test_example.py
@@ -1,6 +1,8 @@
+import uuid
 from datetime import datetime
 from random import random
 from unittest.mock import MagicMock
+from uuid import NAMESPACE_DNS, uuid3, uuid4, uuid5
 
 from pytest_matchers import (
     anything,
@@ -18,6 +20,8 @@ from pytest_matchers import (
     is_number,
     is_strict_dict,
     is_string,
+    is_uuid,
+    one_of,
     same_value,
 )
 
@@ -191,3 +195,15 @@ def test_compare_strict_dictionaries():
         when_true={"c": True},
         when_false={"c": False},
     )
+
+
+def test_uuids():
+    assert uuid4() == is_uuid()
+    assert str(uuid4()) == is_uuid()
+    assert uuid4() != is_uuid(version=1)
+    assert uuid4() == is_uuid(version=4)
+    assert str(uuid4()) != is_uuid(uuid.UUID)
+    assert uuid4() != is_uuid(str)
+    for uuid_value in (uuid3(NAMESPACE_DNS, "python.org"), uuid4()):
+        assert uuid_value == is_uuid(version=one_of(3, 4))
+    assert uuid5(NAMESPACE_DNS, "python.org") != is_uuid(version=one_of(3, 4))

--- a/src/pytest_matchers/tests/matchers/test_uuid.py
+++ b/src/pytest_matchers/tests/matchers/test_uuid.py
@@ -1,0 +1,61 @@
+from uuid import NAMESPACE_DNS, uuid3, uuid4
+
+from pytest_matchers import one_of
+from pytest_matchers.matchers import UUID
+
+
+def test_create():
+    matcher = UUID()
+    assert isinstance(matcher, UUID)
+    matcher = UUID(version=4)
+    assert isinstance(matcher, UUID)
+    matcher = UUID(version=5)
+    assert isinstance(matcher, UUID)
+    matcher = UUID(version=9)
+    assert isinstance(matcher, UUID)
+
+
+def test_repr():
+    matcher = UUID()
+    assert repr(matcher) == "To be a UUID"
+    matcher = UUID(str)
+    assert repr(matcher) == "To be a UUID of 'str' instance"
+    matcher = UUID(version=4)
+    assert repr(matcher) == "To be a UUID with version equal to 4"
+    matcher = UUID(version=9)
+    assert repr(matcher) == "To be a UUID with version equal to 9"
+    matcher = UUID(str, version=5)
+    assert repr(matcher) == "To be a UUID of 'str' instance and with version equal to 5"
+    matcher = UUID(str, version=one_of(3, 4))
+    assert repr(matcher) == "To be a UUID of 'str' instance and with version 3 or 4"
+
+
+def test_matches():
+    valid_uuid_str = "550e8400-e29b-41d4-a716-446655440000"
+    invalid_hex_uuid_str = "550e8400-e29b-41d4-a716-44665544000j"
+    too_long_uuid = "550e8400-e29b-41d4-a716-4466554400000"
+    valid_uuid_3 = uuid3(NAMESPACE_DNS, "python.org")
+    matcher = UUID()
+    assert matcher == valid_uuid_str
+    assert matcher == str(uuid4())
+    assert matcher == uuid4()
+    assert matcher == valid_uuid_3
+    assert matcher == str(valid_uuid_3)
+    assert matcher != "not a UUID"
+    assert matcher != invalid_hex_uuid_str
+    assert matcher != too_long_uuid
+    matcher = UUID(str)
+    assert matcher == valid_uuid_str
+    assert matcher == str(uuid4())
+    assert matcher == str(valid_uuid_3)
+    assert matcher != uuid4()
+    assert matcher != valid_uuid_3
+    matcher = UUID(version=4)
+    assert matcher == valid_uuid_str
+    assert matcher == str(uuid4())
+    assert matcher == uuid4()
+    assert matcher != valid_uuid_3
+    matcher = UUID(str, version=3)
+    assert matcher != valid_uuid_3
+    assert matcher == str(valid_uuid_3)
+    assert matcher != valid_uuid_str

--- a/src/pytest_matchers/tests/test_main.py
+++ b/src/pytest_matchers/tests/test_main.py
@@ -1,5 +1,7 @@
+import uuid
 from datetime import datetime
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 from pytest_matchers import (
     anything,
@@ -18,6 +20,7 @@ from pytest_matchers import (
     is_number,
     is_strict_dict,
     is_string,
+    is_uuid,
     one_of,
     same_value,
 )
@@ -244,3 +247,13 @@ def test_is_json():
     assert '{"key": 4}' == is_json({"key": 4}, exclude=["other"])
     assert '{"key": 4, "other": 10}' != is_json({"key": 4}, exclude=["other"])
     assert '{"key": 4, "other": "string"}' == is_json({"key": 4, "other": is_string()})
+
+
+def test_is_uuid():
+    assert uuid4() == is_uuid()
+    assert uuid4() == is_uuid(version=4)
+    assert uuid4() != is_uuid(version=5)
+    assert uuid4() != is_uuid(str)
+    assert str(uuid4()) == is_uuid()
+    assert str(uuid4()) == is_uuid(str)
+    assert str(uuid4()) != is_uuid(uuid.UUID)

--- a/src/pytest_matchers/tests/utils/test_repr_utils.py
+++ b/src/pytest_matchers/tests/utils/test_repr_utils.py
@@ -13,7 +13,7 @@ def test_concat_matcher_repr():
     matcher = Eq(3)
     assert concat_matcher_repr(matcher) == "equal to 3"
     matcher = None
-    assert concat_matcher_repr(matcher) is None
+    assert concat_matcher_repr(matcher) == ""
 
 
 def test_concat_reprs():


### PR DESCRIPTION
Adding UUID matcher:
```python
def test_uuids():
    assert uuid4() == is_uuid()
    assert str(uuid4()) == is_uuid()
    assert uuid4() != is_uuid(version=1)
    assert uuid4() == is_uuid(version=4)
    assert str(uuid4()) != is_uuid(uuid.UUID)
    assert uuid4() != is_uuid(str)
    for uuid_value in (uuid3(NAMESPACE_DNS, "python.org"), uuid4()):
        assert uuid_value == is_uuid(version=one_of(3, 4))
    assert uuid5(NAMESPACE_DNS, "python.org") != is_uuid(version=one_of(3, 4))
```