### PR TITLE
fix: New is_exception matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ Actual   :0.9048172867693559
 - `is_strict_dict`
 - `is_json`
 - `is_uuid`
+- `is_exception`

--- a/src/pytest_matchers/pytest_matchers/__init__.py
+++ b/src/pytest_matchers/pytest_matchers/__init__.py
@@ -11,6 +11,7 @@ from .main import (
     is_datetime,
     is_datetime_string,
     is_dict,
+    is_exception,
     is_float,
     is_instance,
     is_int,

--- a/src/pytest_matchers/pytest_matchers/main.py
+++ b/src/pytest_matchers/pytest_matchers/main.py
@@ -10,6 +10,7 @@ from pytest_matchers.matchers import (
     DatetimeString,
     Dict,
     DifferentValue,
+    ExceptionMatcher,
     HasAttribute,
     If,
     IsInstance,
@@ -182,3 +183,12 @@ def is_json(matching: dict = None, *, exclude: list[Any] = None) -> JSON:
 
 def is_uuid(matching_type: Type = None, *, version: int | Matcher = None) -> UUID:
     return UUID(matching_type, version=version)
+
+
+def is_exception(
+    exception_type: Type[Exception] = Exception,
+    message: str | Matcher | None = None,
+    *,
+    match_subclass: bool = False,
+) -> ExceptionMatcher:
+    return ExceptionMatcher(exception_type, message, match_subclass)

--- a/src/pytest_matchers/pytest_matchers/matchers/__init__.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/__init__.py
@@ -27,3 +27,4 @@ from .json import JSON
 from .strict_dict import StrictDict
 from .uuid import UUID
 from .timestamp import Timestamp
+from .exception import ExceptionMatcher

--- a/src/pytest_matchers/pytest_matchers/matchers/exception.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/exception.py
@@ -1,0 +1,40 @@
+from builtins import Exception
+
+from pytest_matchers.matchers import Matcher
+from pytest_matchers.utils.matcher_utils import as_matcher_or_none, matches_or_none
+from pytest_matchers.utils.repr_utils import concat_matcher_repr
+
+
+class ExceptionMatcher(Matcher):
+    def __init__(
+        self,
+        exception_type: type[Exception] = Exception,
+        message: str | Matcher | None = None,
+        match_subclass: bool = False,
+    ):
+        super().__init__()
+        self._exception_type = exception_type
+        self._message_matcher = as_matcher_or_none(message)
+        self._match_subclass = match_subclass
+
+    def matches(self, value: Exception) -> bool:
+        return self._matches_type(value) and self._matches_message(value)
+
+    def __repr__(self) -> str:
+        representation = "To be an exception"
+        if self._match_subclass:
+            representation += " instance of"
+        else:
+            representation += " of type"
+        representation += f" {self._exception_type.__name__}"
+        if self._message_matcher:
+            representation += f" with message expected {concat_matcher_repr(self._message_matcher)}"
+        return representation
+
+    def _matches_type(self, value: Exception) -> bool:
+        if self._match_subclass:
+            return isinstance(value, self._exception_type)
+        return type(value) == self._exception_type  # pylint: disable=unidiomatic-typecheck
+
+    def _matches_message(self, value: Exception) -> bool:
+        return matches_or_none(self._message_matcher, str(value))

--- a/src/tests/examples/test_example.py
+++ b/src/tests/examples/test_example.py
@@ -10,12 +10,12 @@ from pytest_matchers import (
     between,
     case,
     different_value,
-    has_attribute,
     if_false,
     if_true,
     is_datetime,
     is_datetime_string,
     is_dict,
+    is_exception,
     is_instance,
     is_list,
     is_number,
@@ -55,18 +55,18 @@ def test_dict_comparison():
     assert value != {"string": is_instance(str), "int": is_instance(int)}
 
 
-def test_mock_log_exception():
-    def _logging_function(logging):
+def test_exception_logging():
+    def _logging_function(logging, message: str):
         try:
-            raise ValueError("This is a test exception")
+            raise ValueError(message)
         except ValueError as error:
             logging.exception("Caught exception: %s", error)
 
     mock_logging = MagicMock()
-    _logging_function(mock_logging)
+    _logging_function(mock_logging, "This is an unexpected exception")
     mock_logging.exception.assert_called_with(
         "Caught exception: %s",
-        is_instance(ValueError) & has_attribute("args", ("This is a test exception",)),
+        is_exception(ValueError, message=is_string(contains="unexpected")),
     )
 
 

--- a/src/tests/matchers/test_exeception.py
+++ b/src/tests/matchers/test_exeception.py
@@ -1,0 +1,72 @@
+from pytest_matchers import is_string
+from pytest_matchers.matchers import ExceptionMatcher
+
+
+def test_create():
+    matcher = ExceptionMatcher()
+    assert isinstance(matcher, ExceptionMatcher)
+    matcher = ExceptionMatcher(Exception)
+    assert isinstance(matcher, ExceptionMatcher)
+    matcher = ExceptionMatcher(Exception, "message")
+    assert isinstance(matcher, ExceptionMatcher)
+    matcher = ExceptionMatcher(Exception, "message", True)
+    assert isinstance(matcher, ExceptionMatcher)
+
+
+def test_matches_type():
+    matcher = ExceptionMatcher()
+    assert matcher == Exception()
+    assert matcher != ValueError()
+    assert matcher != "string"
+    matcher = ExceptionMatcher(ValueError)
+    assert matcher != Exception()
+    assert matcher == ValueError()
+    matcher = ExceptionMatcher(Exception, match_subclass=True)
+    assert matcher == Exception()
+    assert matcher == ValueError()
+
+
+def test_matches_message():
+    matcher = ExceptionMatcher(message="message")
+    assert matcher == Exception("message")
+    assert matcher != Exception("another message")
+    assert matcher != Exception()
+    assert matcher != ValueError("message")
+    matcher = ExceptionMatcher(Exception, "message")
+    assert matcher == Exception("message")
+    assert matcher != Exception("another message")
+    assert matcher != Exception()
+    assert matcher != ValueError("message")
+    matcher = ExceptionMatcher(Exception, "message", True)
+    assert matcher == Exception("message")
+    assert matcher != Exception("another message")
+    assert matcher != Exception()
+    assert matcher == ValueError("message")
+    matcher = ExceptionMatcher(Exception, "")
+    assert matcher == Exception()
+    assert matcher != Exception("message")
+    assert matcher == Exception("")
+    matcher = ExceptionMatcher(Exception, is_string(starts_with="message"))
+    assert matcher == Exception("message")
+    assert matcher == Exception("message and more")
+    assert matcher != Exception("another message")
+
+
+def test_repr():
+    matcher = ExceptionMatcher()
+    assert repr(matcher) == "To be an exception of type Exception"
+    matcher = ExceptionMatcher(ValueError)
+    assert repr(matcher) == "To be an exception of type ValueError"
+    matcher = ExceptionMatcher(ValueError, "message")
+    assert repr(matcher) == (
+        "To be an exception of type ValueError with message expected equal to 'message'"
+    )
+    matcher = ExceptionMatcher(ValueError, "message", True)
+    assert repr(matcher) == (
+        "To be an exception instance of ValueError with message expected equal to 'message'"
+    )
+    matcher = ExceptionMatcher(ValueError, is_string(starts_with="message"))
+    assert repr(matcher) == (
+        "To be an exception of type ValueError "
+        "with message expected to be a string with start expected equal to 'message'"
+    )

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -19,6 +19,7 @@ from pytest_matchers import (
     is_datetime,
     is_datetime_string,
     is_dict,
+    is_exception,
     is_float,
     is_instance,
     is_int,
@@ -385,3 +386,14 @@ def test_is_uuid():
     assert str(uuid4()) == is_uuid()
     assert str(uuid4()) == is_uuid(str)
     assert str(uuid4()) != is_uuid(uuid.UUID)
+
+
+def test_is_exception():
+    assert Exception() == is_exception()
+    assert Exception("message") == is_exception(message="message")
+    assert Exception("message") == is_exception(Exception, "message")
+    assert Exception("message") != is_exception(ValueError, "message")
+    assert Exception("message") != is_exception(Exception, "another_message")
+    assert ValueError("message") == is_exception(ValueError, "message")
+    assert ValueError("message") != is_exception(Exception, "message")
+    assert ValueError("message") == is_exception(Exception, match_subclass=True)


### PR DESCRIPTION
```python
def test_is_exception():
    assert Exception() == is_exception()
    assert Exception("message") == is_exception(message="message")
    assert Exception("message") == is_exception(Exception, "message")
    assert Exception("message") != is_exception(ValueError, "message")
    assert Exception("message") != is_exception(Exception, "another_message")
    assert ValueError("message") == is_exception(ValueError, "message")
    assert ValueError("message") != is_exception(Exception, "message")
    assert ValueError("message") == is_exception(Exception, match_subclass=True)
```