### PR TITLE
fix: length=0 / min_length=0 silently ignored in Length matcher

### DIFF
--- a/src/pytest_matchers/pytest_matchers/matchers/length.py
+++ b/src/pytest_matchers/pytest_matchers/matchers/length.py
@@ -8,8 +8,8 @@ from pytest_matchers.matchers.matcher_factory import matcher
 class Length(Matcher):
     def __init__(self, length=None, min_length=None, max_length=None):
         super().__init__()
-        if length:
-            if min_length or max_length:
+        if length is not None:
+            if min_length is not None or max_length is not None:
                 raise ValueError("Cannot specify length with min_length or max_length")
             min_length = length
             max_length = length
@@ -21,8 +21,8 @@ class Length(Matcher):
             value_length = len(value)
         except TypeError:
             return False
-        matches_min = self._min_length <= value_length if self._min_length else True
-        matches_max = value_length <= self._max_length if self._max_length else True
+        matches_min = self._min_length <= value_length if self._min_length is not None else True
+        matches_max = value_length <= self._max_length if self._max_length is not None else True
         return matches_min and matches_max
 
     def _length_repr(self) -> str:

--- a/src/tests/matchers/test_length.py
+++ b/src/tests/matchers/test_length.py
@@ -17,10 +17,18 @@ def test_create():
     ):
         Length(length=1, min_length=1)
 
+    with pytest.raises(
+        ValueError,
+        match="Cannot specify length with min_length or max_length",
+    ):
+        Length(length=0, min_length=1)
+
 
 def test_repr():
     matcher = Length()
     assert repr(matcher) == ""
+    matcher = Length(length=0)
+    assert repr(matcher) == "To have length of 0"
     matcher = Length(length=1)
     assert repr(matcher) == "To have length of 1"
     matcher = Length(min_length=1, max_length=3)
@@ -52,6 +60,21 @@ def test_matches_exact_length():
     assert not matcher.matches([])
     assert not matcher.matches([1, 2])
     assert not matcher.matches("string")
+
+
+def test_matches_exact_length_zero():
+    matcher = Length(length=0)
+    assert matcher.matches("")
+    assert matcher.matches([])
+    assert not matcher.matches("a")
+    assert not matcher.matches([1])
+
+
+def test_matches_min_length_zero():
+    matcher = Length(min_length=0, max_length=3)
+    assert matcher.matches("")
+    assert matcher.matches("abc")
+    assert not matcher.matches("abcd")
 
 
 def test_matches_min_and_max_length():

--- a/src/tests/matchers/test_string.py
+++ b/src/tests/matchers/test_string.py
@@ -59,6 +59,14 @@ def test_matches_exact_length():
     assert matcher != "string"
 
 
+def test_matches_exact_length_zero():
+    matcher = String(length=0)
+    assert matcher == ""
+    assert matcher != "a"
+    assert matcher != 20
+    assert matcher != None  # pylint: disable=singleton-comparison
+
+
 def test_matches_min_and_max_length():
     matcher = String(min_length=1, max_length=3)
     assert matcher == "a"


### PR DESCRIPTION
## Summary

`Length.__init__` and `Length.matches` both used truthy checks (`if length:`, `if self._min_length else True`, `if self._max_length else True`) instead of `is not None`. Since `0` is falsy, passing `length=0` or `min_length=0` silently dropped the bound and the matcher fell back to matching anything.

This means `is_string(length=0)` — the natural way to assert an exact empty string while still checking the type — never actually enforced the length check. We hit this at Housecall Pro adopting a stricter Ruff ruleset that flagged `assert not some_value` as too loose (accepts `None`/`False`/`0` in addition to `""`), and reached for `is_string(length=0)` as the fix, only to find it didn't actually validate emptiness.

## Changes

- `Length.__init__`: `if length:` → `if length is not None:` (and the nested `min_length or max_length` check → `is not None` too, for the same reason)
- `Length.matches`: both bound checks switched from truthy to `is not None`
- Added regression tests for `length=0`, `min_length=0`, and the `Length(length=0, min_length=1)` conflict case (which now correctly raises, instead of silently ignoring `length`)

## Test plan

- [x] `pytest src/tests` — 265 passed (262 baseline + 3 new)
- [x] `coverage run && coverage report` — 100%
- [x] `black --check src`, `isort --check-only src` — clean